### PR TITLE
XDD: fixes truncation of decimals values to integers

### DIFF
--- a/packages/xmldom-decorators-cli/src/toposort.ts
+++ b/packages/xmldom-decorators-cli/src/toposort.ts
@@ -50,7 +50,7 @@ export function toposort<T>(nodes: T[], edges: [T, T][], cycleCallback: Function
     if (visited[i]) return;
     visited[i] = true
 
-    var outgoing = Array.from(outgoingEdges.get(node) || new Set());
+    var outgoing = Array.from<T>(outgoingEdges.get(node) || new Set());
 
     if (i = outgoing.length) {
       predecessors.add(node)

--- a/packages/xmldom-decorators-test/src/xmlserializer.test.ts
+++ b/packages/xmldom-decorators-test/src/xmlserializer.test.ts
@@ -45,6 +45,24 @@ class TextInRoot {
 }
 
 @XMLRoot()
+class IntegerInRoot {
+	@XMLElement()
+	intElement: number = 0;
+
+	@XMLAttribute()
+	intAttribute?: number;
+}
+
+@XMLRoot()
+class DecimalInRoot {
+	@XMLElement()
+	decimalElement: number = 1.2;
+
+	@XMLAttribute()
+	decimalAttribute?: number;
+}
+
+@XMLRoot()
 class DateInRoot {
 	@XMLElement()
 	dateElement: Date = new Date(0);
@@ -254,15 +272,35 @@ export class SetOfTests {
 		expect(x).toEqual(o);
 	}
 
-	@Test("Date")
-	public dateTest() {
-		const o: DateInRoot = { dateAttribute: new Date("2018-05-05Z"), dateElement: new Date("2018-05-05T13:14Z") };
-		const result = serialize(o, DateInRoot);
-		expect(result).toBe('<DateInRoot dateAttribute="2018-05-05T00:00:00.000Z"><dateElement>2018-05-05T13:14:00.000Z</dateElement></DateInRoot>');
+  @Test("Integer")
+  public integerTest() {
+    const o: IntegerInRoot = { intAttribute: 7, intElement: 11 };
+    const result = serialize(o, IntegerInRoot);
+    expect(result).toBe('<IntegerInRoot intAttribute="7"><intElement>11</intElement></IntegerInRoot>');
 
-		const x: any = deserialize(result, DateInRoot);
-		expect(x).toEqual(o);
-	}
+    const x: any = deserialize(result, IntegerInRoot);
+    expect(x).toEqual(o);
+  }
+
+  @Test("Decimal")
+  public decimalTest() {
+    const o: DecimalInRoot = { decimalAttribute: 7.11 as number, decimalElement: 11.7 as number };
+    const result = serialize(o, DecimalInRoot);
+    expect(result).toBe('<DecimalInRoot decimalAttribute="7.11"><decimalElement>11.7</decimalElement></DecimalInRoot>');
+
+    const x: any = deserialize(result, DecimalInRoot);
+    expect(x).toEqual(o);
+  }
+
+  @Test("Date")
+  public dateTest() {
+    const o: DateInRoot = { dateAttribute: new Date("2018-05-05Z"), dateElement: new Date("2018-05-05T13:14Z") };
+    const result = serialize(o, DateInRoot);
+    expect(result).toBe('<DateInRoot dateAttribute="2018-05-05T00:00:00.000Z"><dateElement>2018-05-05T13:14:00.000Z</dateElement></DateInRoot>');
+
+    const x: any = deserialize(result, DateInRoot);
+    expect(x).toEqual(o);
+  }
 
 	@Test("Nested array in root")
 	public nestedArrayInRoot() {
@@ -384,7 +422,7 @@ export class SetOfTests {
 		// <main>
 		const a = serialize(o, MultiRootDecorator, "main");
 		expect(a).toBe('<main name="test"/>');
-		
+
 		const x: any = deserialize(a, MultiRootDecorator);
 		expect(x.constructor).toBe(MultiRootDecorator);
 		expect(x).toEqual(o);
@@ -512,7 +550,7 @@ export class SetOfTests {
 				]})
 				things?: string[];
 			}
-				
+
 		}).toThrow(); // new Error("@XMLArray must declare item type on things")
 	}
 

--- a/packages/xmldom-decorators/package.json
+++ b/packages/xmldom-decorators/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@types/node": "^10.12.7",
     "@types/xmldom": "^0.1.29",
-    "typescript": "^3.3.1"
+    "typescript": "~3.3.1"
   },
   "dependencies": {
     "reflect-metadata": "^0.1.12",

--- a/packages/xmldom-decorators/src/deserializer.ts
+++ b/packages/xmldom-decorators/src/deserializer.ts
@@ -1,5 +1,16 @@
-import { XMLReader, Locator, DOMBuilder, ElementAttributes } from "xmldom/sax";
-import { RootSchema, ArraySchema, BaseSchema, ArrayItemOptions, isRootSchema, isElementSchema, isArraySchema, ElementSchema, TextSchema, AttributeSchema, isTextSchema } from "./decorators";
+import { DOMBuilder, ElementAttributes, Locator, XMLReader } from "xmldom/sax";
+import {
+  ArrayItemOptions,
+  ArraySchema,
+  AttributeSchema,
+  BaseSchema,
+  ElementSchema,
+  isArraySchema,
+  isElementSchema,
+  isTextSchema,
+  RootSchema,
+  TextSchema
+} from "./decorators";
 
 export function getArrayItemName(schema: ArraySchema, opts: ArrayItemOptions): string {
     if (!schema.nested && !opts.name) {
@@ -165,7 +176,7 @@ class DeserializerBuilder implements DOMBuilder, DeserializerContext {
 
                 // Push a fake array container for this item, reusing the array value
                 const value = parent.value[childSchema.propertyKey] = parent.value[childSchema.propertyKey] || [];
-                
+
                 this.elementStack.push({
                     value: value,
                     elementSchema: childSchema,
@@ -175,7 +186,7 @@ class DeserializerBuilder implements DOMBuilder, DeserializerContext {
                 });
 
                 this.pushValue(childSchema, itemType.itemType(), null, el);
-    
+
             } else if (isArraySchema(childSchema) && childSchema.nested) {
                 // nested array member on object
                 this.pushValue(childSchema, Array, childSchema.propertyKey, el);
@@ -435,8 +446,9 @@ class DeserializerBuilder implements DOMBuilder, DeserializerContext {
         if (type === String) {
             return value;
         } else if (type === Number) {
-            var numberResult = parseInt(value);
-            if (isNaN(numberResult)) {
+            try {
+                var numberResult = Number(value).valueOf();
+            } catch (e) {
                 throw new Error("Cannot convert to number: " + value);
             }
             return numberResult;
@@ -462,7 +474,7 @@ class DeserializerBuilder implements DOMBuilder, DeserializerContext {
 }
 
 export class XMLDecoratorDeserializer {
-    
+
     deserialize<T>(source: string, type: Function|Function[]): T {
 
         // array of types; and array of roots per type


### PR DESCRIPTION
When the type of an property was 'number' the code was always converting it using `parseInt(value)`. This only supported integers, truncating any decimal value. This corrects that by replacing `parseInt(value)` with `Number(value).valueOf()`.

Also:
Adds error message if an object throws in JSON.stringify().
Fixes some compile errors. (There are more with newer Typescript versions).